### PR TITLE
fix default solver for robust regression, MLJ issue 401

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJLinearModels"
 uuid = "6ee0df7b-362f-4a72-a706-9e79364fb692"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/fit/default.jl
+++ b/src/fit/default.jl
@@ -5,22 +5,25 @@ export fit
 # TODO: in the future, have cases where if the things are too big, take another default.
 # also should check if p > n in which case should do dual stuff (or other appropriate alternative)
 
+# Linear, Ridge
 _solver(::GLR{L2Loss,<:L2R}, np::NTuple{2,Int}) = Analytical()
 
+# Logistic, Multinomial
 _solver(::GLR{LogisticLoss,<:L2R}, 	  np::NTuple{2,Int}) = LBFGS()
 _solver(::GLR{MultinomialLoss,<:L2R}, np::NTuple{2,Int}) = LBFGS()
 
-function _solver(glr::GLR{<:SMOOTH_LOSS,<:ENR}, np::NTuple{2,Int})
+# Lasso, ElasticNet, Logistic, Multinomial
+function _solver(glr::GLR{<:SmoothLoss,<:ENR}, np::NTuple{2,Int})
 	(is_l1(glr.penalty) || is_elnet(glr.penalty)) && return FISTA()
-	@error "Not yet implemented"
+	@error "Not yet implemented."
 end
 
-_solver(::GLR{RobustLoss,<:L2R}, np::NTuple{2,Int}) = LBFGS()
-#_solver(::GLR{L1Loss,<:L2R}, 	 np::NTuple{2,Int}) = FADMM()
+# Robust, Quantile
+_solver(::GLR{<:RobustLoss,<:L2R}, np::NTuple{2,Int}) = LBFGS()
 
 # Fallback NOTE: should revisit bc with non-smooth, wouldn't work probably PGD/PSGD
 # depending on how much data there is
-_solver(::GLR, np::NTuple{2,Int}) = @error "Not yet implemented"
+_solver(::GLR, np::NTuple{2,Int}) = @error "Not yet implemented."
 
 
 """

--- a/src/glr/utils.jl
+++ b/src/glr/utils.jl
@@ -1,7 +1,7 @@
 export objective, smooth_objective
 
 # NOTE: RobustLoss are not always everywhere  smooth but "smooth-enough".
-const SMOOTH_LOSS = Union{L2Loss, LogisticLoss, MultinomialLoss, RobustLoss}
+const SmoothLoss = Union{L2Loss, LogisticLoss, MultinomialLoss, RobustLoss}
 
 """
 $SIGNATURES
@@ -34,7 +34,7 @@ $SIGNATURES
 
 Return the smooth part of the objective function of a GLR.
 """
-smooth_objective(glr::GLR{<:SMOOTH_LOSS,<:ENR}) = glr.loss + get_l2(glr.penalty)
+smooth_objective(glr::GLR{<:SmoothLoss,<:ENR}) = glr.loss + get_l2(glr.penalty)
 smooth_objective(::GLR) = @error "Case not implemented yet."
 
 """


### PR DESCRIPTION
RobustRegressions (e.g. Quantile, LAD) had no default solver, this was due to an improperly typed `_solver` function (which returns the default solver for a regression/classification).

**Note**: patch release, will need update of MLJRegistry